### PR TITLE
Adding GitHub workflow to push to Docker Hub

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -24,7 +24,14 @@ jobs:
         run: |
           calculatedSha=$(git rev-parse --short ${{ github.sha }})
           imageTag=misirloutg/disguise:$calculatedSha
-          echo "Will build and push" $imageTag
+          echo "IMAGE_TAG=$imageTag"
           echo "IMAGE_TAG=$imageTag" >> $GITHUB_ENV
+      # Build and push the image
+      - name: Build and push
+        id: build_push
+        uses: docker/build-push-action@v6
+        with:
+          #push: true
+          tags: ${{ env.IMAGE_TAG }}
       - name: Test, test, test
-        run: echo ${{ env.IMAGE_TAG }}
+        run: echo "imageId:" ${{ steps.build_push.outputs.imageId }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -15,6 +15,10 @@ name: build-and-push
 #
 
 on:
+  # Runs on pushes targeting master
+  push:
+    branches:
+      - master
   # Allows the ability to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -41,15 +41,15 @@ jobs:
           echo "IMAGE_TAG=$imageTag"
           echo "IMAGE_TAG=$imageTag" >> $GITHUB_ENV
       # Login to Docker Hub
-#      - name: Login to Docker Hub
-#        uses: docker/login-action@v3
-#        with:
-#          username: ${{ vars.DOCKERHUB_USERNAME }}
-#          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       # Build and push the image
-#      - name: Build and push
-#        id: build_push
-#        uses: docker/build-push-action@v6
-#        with:
-#          push: true
-#          tags: ${{ env.IMAGE_TAG }}
+      - name: Build and push
+        id: build_push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ${{ env.IMAGE_TAG }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -52,7 +52,6 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       # Build and push the image
       - name: Build and push
-        id: build_push
         uses: docker/build-push-action@v6
         with:
           push: true

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -13,23 +13,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Build job
-  build:
+  build-push:
     runs-on: ubuntu-latest
     steps:
-      # Checkout & setup pages
+      # Checkout & set image tag based on the commit hash
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Test, test, test
-        run: |
-          ls -l
-          docker --version
-      - name: Get short git commit hash
+      - name: Set env.IMAGE_TAG for our docker hub repo
+        # https://dev.to/hectorleiva/github-actions-and-creating-a-short-sha-hash-8b7
         run: |
           calculatedSha=$(git rev-parse --short ${{ github.sha }})
-          echo "Short hash: $calculatedSha"
-
-  # Push job
-#  push:
-#    needs: build
-#    runs-on: ubuntu-latest
+          echo "IMAGE_TAG=misirloutg/disguise:$calculatedSha" >> $GITHUB_ENV
+          echo "Will build and push" ${{ env.IMAGE_TAG }}
+      - name: Test, test, test
+        run: echo ${{ env.IMAGE_TAG }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -19,6 +19,8 @@ on:
   push:
     branches:
       - master
+  # Pull requests
+  pull_request:
   # Allows the ability to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -37,6 +39,16 @@ jobs:
       # Checkout & set image tag based on the commit hash
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Set push operation
+        id: set-push
+        run: |
+          if [ '${{ github.event_name }}' = 'pull_request' ]; then
+            echo "PR workflow, only building image"
+            echo "doPush=false" >> $GITHUB_OUTPUT
+          else
+            echo "Other workflow, build and push image"
+            echo "doPush=true" >> $GITHUB_OUTPUT
+          fi
       - name: Set env.IMAGE_TAG for our docker hub repo
         # https://dev.to/hectorleiva/github-actions-and-creating-a-short-sha-hash-8b7
         run: |
@@ -46,6 +58,7 @@ jobs:
           echo "IMAGE_TAG=$imageTag" >> $GITHUB_ENV
       # Login to Docker Hub
       - name: Login to Docker Hub
+        if: steps.set-push.outputs.doPush == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
@@ -54,5 +67,5 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          push: true
+          push: ${{ steps.set-push.outputs.doPush == 'true' }}
           tags: ${{ env.IMAGE_TAG }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -23,7 +23,8 @@ jobs:
         # https://dev.to/hectorleiva/github-actions-and-creating-a-short-sha-hash-8b7
         run: |
           calculatedSha=$(git rev-parse --short ${{ github.sha }})
-          echo "IMAGE_TAG=misirloutg/disguise:$calculatedSha" >> $GITHUB_ENV
-          echo "Will build and push" ${{ env.IMAGE_TAG }}
+          imageTag=misirloutg/disguise:$calculatedSha
+          echo "Will build and push" $imageTag
+          echo "IMAGE_TAG=$imageTag" >> $GITHUB_ENV
       - name: Test, test, test
         run: echo ${{ env.IMAGE_TAG }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,5 +1,19 @@
 name: build-and-push
 
+#
+# This uses Docker's GitHub Actions to build and push the image to our Docker Hub repo:
+# https://docs.docker.com/build/ci/github-actions/
+#
+# Also some information in the actions' GitHub repo:
+# https://github.com/docker/login-action
+# https://github.com/docker/build-push-action
+#
+# Note: This workflow requires that the Docker Hub username & a personal
+# access token (PAT) are configured in GitHub for the repository:
+# - Repostory var: DOCKERHUB_USERNAME
+# - Repostiory secret: DOCKERHUB_TOKEN
+#
+
 on:
   # Allows the ability to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -23,15 +37,19 @@ jobs:
         # https://dev.to/hectorleiva/github-actions-and-creating-a-short-sha-hash-8b7
         run: |
           calculatedSha=$(git rev-parse --short ${{ github.sha }})
-          imageTag=misirloutg/disguise:$calculatedSha
+          imageTag=${{ vars.DOCKERHUB_USERNAME }}/disguise:$calculatedSha
           echo "IMAGE_TAG=$imageTag"
           echo "IMAGE_TAG=$imageTag" >> $GITHUB_ENV
+      # Login to Docker Hub
+#      - name: Login to Docker Hub
+#        uses: docker/login-action@v3
+#        with:
+#          username: ${{ vars.DOCKERHUB_USERNAME }}
+#          password: ${{ secrets.DOCKERHUB_TOKEN }}
       # Build and push the image
-      - name: Build and push
-        id: build_push
-        uses: docker/build-push-action@v6
-        with:
-          #push: true
-          tags: ${{ env.IMAGE_TAG }}
-      - name: Test, test, test
-        run: echo "imageId:" ${{ steps.build_push.outputs.imageId }}
+#      - name: Build and push
+#        id: build_push
+#        uses: docker/build-push-action@v6
+#        with:
+#          push: true
+#          tags: ${{ env.IMAGE_TAG }}


### PR DESCRIPTION
This fills in the build-and-push workflow with the steps to build and push the image to Docker Hub.

There are notes in the workflow file about a variable and a secret for the Docker Hub username and token that need to be added in GitHub. They are easily added in the GitHub UI, I added them as Repository (not Environment) values, but I think they can be added in either place.
