### PR TITLE
Modifying nginx config to better serve up Angular application

### DIFF
--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -26,6 +26,9 @@ server {
     }
 
     location / {
+        gzip on;
+        gzip_min_length 100;
+        gzip_types text/css application/javascript;
         try_files $uri @index;
     }
 

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -20,12 +20,12 @@ server {
         proxy_pass ${MBTEST_URL};
     }
 
-    error_page  404              /404.html;
+    #error_page  404              /404.html;
 
     # redirect server error pages to the static page /50x.html
     #
-    #error_page   500 502 503 504  /50x.html;
-    #location = /50x.html {
-    #    root   /usr/share/nginx/html;
-    #}
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
 }

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -5,9 +5,34 @@ server {
 
     #access_log  /var/log/nginx/host.access.log  main;
 
+    # Found this solution for serving up an Angular app where we want to make
+    # sure index.html is not cached by browsers. The solution also uses try_files,
+    # which we were not using before, which makes it nicer for users because a URL
+    # like "http://<host>/logs" will actually respond with index.html and Angular
+    # will start on the Logs page. Previously this would have resulted in a 404.
+    #
+    # Note that I moved the root directive to the server level so that it is
+    # not repeated for the three location directives.
+    #
+    # https://nginx.org/en/docs/http/ngx_http_core_module.html#location
+    # https://stackoverflow.com/questions/41631399/disable-caching-of-a-single-file-with-try-files-directive
+
+    root /usr/share/nginx/html;
+
+    location = / {
+        add_header Cache-Control no-cache;
+        expires 0;
+        try_files /index.html =404;
+    }
+
     location / {
-        root   /usr/share/nginx/html;
-        index  index.html;
+        try_files $uri @index;
+    }
+
+    location @index {
+        add_header Cache-Control no-cache;
+        expires 0;
+        try_files /index.html =404;
     }
 
     # proxy endpoints that begin with this to mbtest


### PR DESCRIPTION
Found this solution for serving up an Angular app where we want to make sure index.html is not cached by browsers. The solution also uses `try_files`, which we were not using before, which makes it nicer for users because a URL like `http://<host>/logs` will actually respond with index.html and Angular will start on the Logs page. Previously this would have resulted in a 404.
