### PR TITLE
Refactoring build-and-push workflow to cleanup image names/tags

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -38,8 +38,10 @@ jobs:
     name: 🔨 Build and Push to Docker Hub
 
     env:
+      # This is the repo the image will be pushed to
       DOCKER_REPO: ${{ vars.DOCKERHUB_USERNAME }}/disguise
-      # IMAGE_TAG will also be available (added in one of the steps)
+      # IMAGE_NAME_LATEST and IMAGE_NAME_COMMIT_HASH will also be added
+      # to env by appending tags to DOCKER_REPO
 
     steps:
       - name: 📥 Checkout repository
@@ -59,18 +61,17 @@ jobs:
             echo "doPush=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # Set image tag to the commit's short hash
-      - name: ⚙️ Set env.IMAGE_TAG for our Docker Hub repo
+      - name: ⚙️ Add IMAGE_NAMEs to env
+        # Two tags "latest" and "commitHash" will be added to DOCKER_REPO
         # https://dev.to/hectorleiva/github-actions-and-creating-a-short-sha-hash-8b7
         run: |
-          calculatedSha=$(git rev-parse --short ${{ github.sha }})
-          imageTag=${DOCKER_REPO}:${calculatedSha}
-          echo "IMAGE_TAG=${imageTag}"
-          echo "IMAGE_TAG=${imageTag}" >> "$GITHUB_ENV"
+          echo "IMAGE_NAME_LATEST=${DOCKER_REPO}:latest" >> "$GITHUB_ENV"
+          short_hash=$(git rev-parse --short ${{ github.sha }})
+          echo "IMAGE_NAME_COMMIT_HASH=${DOCKER_REPO}:${short_hash}" >> "$GITHUB_ENV"
 
       - name: 📝 Adding step summary
         run: |
-          echo 'Building image with tag: `${{ env.IMAGE_TAG }}`' >> "$GITHUB_STEP_SUMMARY"
+          echo 'Building image with tag: `${{ env.IMAGE_NAME_COMMIT_HASH }}`' >> "$GITHUB_STEP_SUMMARY"
           echo 'Performing push: `${{ steps.set-push.outputs.doPush }}`' >> "$GITHUB_STEP_SUMMARY"
 
       # Login to Docker Hub
@@ -87,5 +88,5 @@ jobs:
         with:
           push: ${{ steps.set-push.outputs.doPush == 'true' }}
           tags: |
-            ${{ env.IMAGE_TAG }}
-            ${{ github.ref == 'refs/heads/master' && format('{0}:latest', env.DOCKER_REPO) || '' }}
+            ${{ env.IMAGE_NAME_COMMIT_HASH }}
+            ${{ github.ref == 'refs/heads/master' && env.IMAGE_NAME_LATEST || '' }}


### PR DESCRIPTION
Simplifying the workflow by keeping two env vars that both contain the image name (repository name + image tag) for the image that is being built. There is no change to what will get pushed to the repository, the latest tag will still only be pushed if the build is for the master branch.